### PR TITLE
Add default size options; fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,14 @@ following options:
 	color0e=#93a1a1
 	color0f=#3d36e3
 
-### Scrollbar
+### Misc
+There are several options in the `Misc` section of the configuration file.
+#### Scrollbar
 For a scrollbar, set the `scrollbar-type` setting to either `automatic` or
 `always`. To disable the scrollbar set it to `never`.
+
+#### Size
+The default size can be set with the `columns` and `rows` options.
 
 ### Other
 If the configuration file doesn't exist, Miniterm will create one automatically.

--- a/src/settings.c
+++ b/src/settings.c
@@ -173,18 +173,23 @@ miniterm_write_default_settings(const char *config_path)
 {
 	FILE *file = fopen(config_path, "w");
 	if (file) {
-		fprintf(file, "[Font]\n#font=\n\n"
-			      "[Colors]\n#foreground=\n#background=\n"
-			      "#color00=\n#color01=\n#color02=\n#color03=\n"
-			      "#color04=\n#color05=\n#color06=\n#color07=\n"
-			      "#color08=\n#color09=\n#color0a=\n#color0b=\n"
-			      "#color0c=\n#color0d=\n#color0e=\n#color0f=\n\n"
-			      "[Misc]\n"
-			      "#dynamic-window-title=\n"
-			      "#urgent-on-bell=\n"
-			      "#audible-bell=\n"
-			      "#scrollback-lines=\n"
-			      "#scrollbar-type=\n");
+		fprintf(file,
+			"[Font]\n"
+			"# font=\n\n"
+			"[Colors]\n"
+			"# foreground=\n# background=\n"
+			"# color00=\n# color01=\n# color02=\n# color03=\n"
+			"# color04=\n# color05=\n# color06=\n# color07=\n"
+			"# color08=\n# color09=\n# color0a=\n# color0b=\n"
+			"# color0c=\n# color0d=\n# color0e=\n# color0f=\n\n"
+			"[Misc]\n"
+			"# dynamic-window-title=\n"
+			"# urgent-on-bell=\n"
+			"# audible-bell=\n"
+			"# scrollback-lines=\n"
+			"# scrollbar-type=\n"
+			"# columns=80\n"
+			"# rows=24\n");
 		fclose(file);
 	}
 }

--- a/src/settings.c
+++ b/src/settings.c
@@ -46,6 +46,8 @@ miniterm_settings_init(MinitermSettings *settings)
 	settings->audible_bell = false;
 	settings->scrollback_lines = MINITERM_DEFAULT_SCROLLBACK_LINES;
 	settings->font_name = NULL;
+	settings->columns = 0;
+	settings->rows = 0;
 	settings->has_colors = false;
 }
 
@@ -60,6 +62,8 @@ miniterm_settings_set_from_key_file(
 	config_file_get_scrollbar(&settings->scrollbar_type, config_file);
 	config_file_get_int(&settings->scrollback_lines, config_file, "Misc",
 		"scrollback-lines");
+	config_file_get_int(&settings->columns, config_file, "Misc", "columns");
+	config_file_get_int(&settings->rows, config_file, "Misc", "rows");
 	if (settings->scrollback_lines < 0) {
 		fprintf(stderr, "Invalid scrollback lines: %i\n",
 			settings->scrollback_lines);

--- a/src/settings.h
+++ b/src/settings.h
@@ -41,6 +41,10 @@ struct _MinitermSettings {
 	int scrollback_lines;
 	/* NULL indicates no user defined font. */
 	char *font_name;
+	/* Non-positive indicates no default. */
+	int columns;
+	/* Non-positive indicates no default. */
+	int rows;
 
 	/* Whether or not colors are valid. */
 	bool has_colors;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -179,6 +179,16 @@ update_from_settings(MinitermTerminal *terminal, MinitermSettings *settings)
 			priv->default_font_size = 12 * PANGO_SCALE;
 		pango_font_description_free(font);
 	}
+	if (settings->columns > 0 || settings->rows > 0) {
+		int cols = vte_terminal_get_row_count(VTE_TERMINAL(terminal));
+		int rows =
+			vte_terminal_get_column_count(VTE_TERMINAL(terminal));
+		if (settings->columns > 0)
+			cols = settings->columns;
+		if (settings->rows > 0)
+			rows = settings->rows;
+		vte_terminal_set_size(VTE_TERMINAL(terminal), cols, rows);
+	}
 	if (settings->has_colors)
 		vte_terminal_set_colors(VTE_TERMINAL(terminal),
 			&settings->fg_color, &settings->bg_color,


### PR DESCRIPTION
Adds the options `columns` and `rows` to the configuration file which set the default size the terminal opens to.