### PR TITLE
Export compile commands and add format script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.5.2)
 
 project (miniterm)
+
+# Generate compile_commands.json for integration into completion engines.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_subdirectory (src)
 

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+git ls-files -- '*.c' '*.h' | xargs clang-format -i -style=.clang-format
+git diff --exit-code --color


### PR DESCRIPTION
- Adds CMake command to generate a `compile_commands.json` file which editors can use for completion engines.
- Add a script that runs `clang-format` on files in the repository.